### PR TITLE
Update requirements to include google and anthropic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ torchvision==0.18.0
 tqdm==4.66.4
 transformers==4.40.2
 vllm==0.4.2
-
+anthropic==0.34.2
+google.generativeai==0.8.2


### PR DESCRIPTION
google.generativeai and anthropic modules are required for evaluate_from_api but weren't included in requirements.txt